### PR TITLE
correct package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ matplotlib-inline==0.1.3
 nbgitpuller==1.0.2
 numpy==1.21.5
 pandas==1.3.5
+scikit-learn==1.0.2
 seaborn==0.11.2
-sklearn==0.0
 urllib3==1.26.8

--- a/requirements_raw.txt
+++ b/requirements_raw.txt
@@ -4,5 +4,5 @@ numpy
 pandas
 matplotlib
 seaborn
-sklearn
+scikit-learn
 urllib3


### PR DESCRIPTION

from `sklearn` (which works but does not yield the correct package version) to `scikit-learn`
