### PR TITLE
bump python version to 3.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ the challenges are served through [mybinder](https://www.notion.so/lewagon/B2U-I
 update the contents of `requirements_raw.txt`, then process `requirements.txt` from a new env:
 
 ``` bash
-pyenv install 3.7.12
+pyenv install 3.12.0
 pyenv virtualenv-delete binder
-pyenv virtualenv 3.7.12 binder
+pyenv virtualenv 3.12.0 binder
 pyenv local binder
 pip install -U pip
 export REQ_URL=https://raw.githubusercontent.com/lewagon/intro-to-data-science-env/master/requirements_raw.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 jupyter-offlinenotebook==0.2.2
-matplotlib==3.5.1
-matplotlib-inline==0.1.3
-nbgitpuller==1.0.2
-numpy==1.21.5
-pandas==1.3.5
-scikit-learn==1.0.2
-seaborn==0.11.2
-urllib3==1.26.8
+matplotlib==3.8.0
+matplotlib-inline==0.1.6
+nbgitpuller==1.2.0
+numpy==1.26.0
+pandas==2.1.1
+scikit-learn==1.3.1
+seaborn==0.13.0
+urllib3==2.0.6

--- a/requirements_raw.txt
+++ b/requirements_raw.txt
@@ -3,6 +3,7 @@ jupyter-offlinenotebook
 numpy
 pandas
 matplotlib
+matplotlib-inline
 seaborn
 scikit-learn
 urllib3


### PR DESCRIPTION
current version of python 3.7.12 is not supported since June 6th

this is [suspected](https://nbgitpuller.readthedocs.io/en/latest/install.html#nbgitpuller-link-shows-404-not-found) to generate 404 pages for @TPedelhez's students when opening the notebook repo in mybinder

the new python 3.12.0 should be supported until November, 2028