### PR TITLE
deprecate repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 
+this repo is not useful anymore since the [challenge repo](https://github.com/lewagon/intro-to-data-science-challenges/pull/8) hosts the requirements intepreted by mybinder and is self contained
+
+# deprecated
+
 setup environment for the [Introduction to Data Science](https://github.com/lewagon/intro-to-data-science-challenges) challenges
 
 the challenges are served through [mybinder](https://www.notion.so/lewagon/B2U-Intro-to-Data-Science-f88a9af1afff44109bfd3)
 
-# update package version
+## update package version
 
 update the contents of `requirements_raw.txt`, then process `requirements.txt` from a new env:
 
@@ -19,6 +23,6 @@ pip install $(echo ${PACKAGES})
 pip freeze | grep $(echo ${$(echo ${PACKAGES})/#/-e }) > requirements.txt
 ```
 
-# info
+## info
 
 `build.log` contains the mybinder image build and container start logs


### PR DESCRIPTION
the repo is not required anymore since the [challenge repo](https://github.com/lewagon/intro-to-data-science-challenges) contains the requirements [interpreted](https://mybinder.readthedocs.io/en/latest/using/config_files.html#config-files) by [mybinder](https://mybinder.org/)